### PR TITLE
Integration of AWS Comprehend/Sentiment Analysis

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,3 +34,4 @@ end
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'figgy'
+gem 'aws-sdk-comprehend', '~> 1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,18 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.1, >= 2.1.8)
+    aws-eventstream (1.0.3)
+    aws-partitions (1.230.0)
+    aws-sdk-comprehend (1.26.0)
+      aws-sdk-core (~> 3, >= 3.71.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-core (3.72.0)
+      aws-eventstream (~> 1.0, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.228.0)
+      aws-sigv4 (~> 1.1)
+      jmespath (~> 1.0)
+    aws-sigv4 (1.1.0)
+      aws-eventstream (~> 1.0, >= 1.0.2)
     bootsnap (1.4.5)
       msgpack (~> 1.0)
     builder (3.2.3)
@@ -70,6 +82,7 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.7.0)
       concurrent-ruby (~> 1.0)
+    jmespath (1.4.0)
     json (2.2.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -146,6 +159,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aws-sdk-comprehend (~> 1)
   bootsnap (>= 1.4.2)
   byebug
   figgy

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -1,3 +1,7 @@
+#
+require 'aws-sdk-comprehend'
+
+# SiteController.
 class SiteController < ApplicationController
   def index
     render template: 'pages/index.html'
@@ -10,7 +14,7 @@ class SiteController < ApplicationController
       }, status: :bad_request
     else
       system('python lights.py')
-      render json: { message: message, principal: 'greg' }
+      render json: { message: message, sentiment: sentiment(params[:question]), principal: 'greg' }
     end
   end
 
@@ -19,5 +23,24 @@ class SiteController < ApplicationController
   def message
     words = AppConfig.architecturey.famous_words.sample(3)
     "You should build an application using #{words.to_sentence}."
+  end
+
+  def sentiment(question)
+    resp = client.detect_sentiment(
+      text: question,
+      language_code: 'en'
+    )
+    puts resp
+    resp.sentiment
+  rescue Aws::Comprehend::Errors::ServiceError => e
+    puts e
+
+    'NEUTRAL'
+  end
+
+  def client
+    return @client if @client
+
+    @client = Aws::Comprehend::Client.new(:profile => 'herp_derp')
   end
 end

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -13,8 +13,10 @@ class SiteController < ApplicationController
         error: 'Please describe your project in plain english.'
       }, status: :bad_request
     else
-      system('python lights.py')
-      render json: { message: message, sentiment: sentiment(params[:question]), principal: 'greg' }
+      sentiment = get_sentiment(params[:question])
+      render json: { message: message, sentiment: sentiment, principal: 'greg' }
+      pid = spawn('python lights.py')
+      Process.detach(pid)
     end
   end
 
@@ -25,7 +27,7 @@ class SiteController < ApplicationController
     "You should build an application using #{words.to_sentence}."
   end
 
-  def sentiment(question)
+  def get_sentiment(question)
     resp = client.detect_sentiment(
       text: question,
       language_code: 'en'

--- a/public/assets/css/main.css
+++ b/public/assets/css/main.css
@@ -25,6 +25,35 @@
   transition: height 125ms;
 }
 
+.sentiment-negative {
+  color: red;
+}
+.sentiment-positive {
+  color: green;
+}
+.sentiment-neutral {
+  color: blue;
+}
+.sentiment-mixed {
+  color: black;
+}
+
+.progress-negative {
+  background-color: red !important;
+}
+.progress-positive {
+  background-color: green !important;
+}
+.progress-neutral {
+  background-color: blue !important;
+}
+
+.sentiment-analysis {
+  font-size: 10px;
+  font-variant: small-caps;
+}
+
+
 .speech-bubble:after {
   content: '';
   position: absolute;

--- a/public/index.html
+++ b/public/index.html
@@ -27,7 +27,7 @@
             >
                 <div class="content">
                     <div class="field">
-                        <label class="label" for="question">What Problem Would You Like to Solve?</label>
+                        <label class="label" for="question">Enter the problem you want to solve (technical or non-techncial) and get an answer from Enova's greatest technical minds! Featuring Enterprise Solutions Cloud Architect pumpkin, with our actual Enterprise Architect Greg Lacey and principals.</label>
                         <div class="control">
                             <textarea
                               ref="inputControl"

--- a/public/index.html
+++ b/public/index.html
@@ -13,10 +13,10 @@
                 <div class="hero-body">
                     <div class="content">
                         <h1 class="title">
-                            Web Application Architecture Bot
+                            Solutioning App Architecture
                         </h1>
                         <p class="subtitle">
-                            Featuring Vue.js, Ruby on Rails, AWS Comprehend and Rasberry Pi
+                            Featuring Vue.js, Ruby on Rails, Python, AWS Comprehend and Rasberry Pi
                         </p>
                     </div>
                 </div>

--- a/public/index.html
+++ b/public/index.html
@@ -16,7 +16,7 @@
                             Web Application Architecture Bot
                         </h1>
                         <p class="subtitle">
-                            Featuring Vue.js, AWS Lambda, and Rasberry Pi
+                            Featuring Vue.js, Ruby on Rails, AWS Comprehend and Rasberry Pi
                         </p>
                     </div>
                 </div>
@@ -30,6 +30,7 @@
                         <label class="label" for="question">What Problem Would You Like to Solve?</label>
                         <div class="control">
                             <textarea
+                              ref="inputControl"
                               v-model="question"
                               id="question"
                               class="textarea"
@@ -53,14 +54,19 @@
               class="section"
             >
                 <div class="content">
-                    <h2>{{ principalName }} Says</h2>
+                  <h2>You said</h2>
+                  <i>"{{ question }}"</i>
+                  <div class="sentiment-analysis">
+                    (which has a {{ sentiment }} sentiment)
+                  </div>
+                  <h2>{{ principalName }} says</h2>
                     <div class="principal">
                       <img
                         class="principal__img"
                         :src="`assets/img/${principal}.jpg`"
                         alt=""
                       >
-                      <div class="speech-bubble">{{ bubbleText }}</div>
+                      <div class="speech-bubble" :class="sentimentClass">{{ bubbleText }}</div>
                     </div>
                     <div class="field">
                         <div class="control">
@@ -84,6 +90,7 @@
                         <progress
                           class="progress is-small is-primary"
                           max="100"
+                          :class="progressBarClass"
                         >15%</progress>
                     </div>
                   </section>
@@ -99,8 +106,11 @@
               step: 1,
               loading: false,
               question: '',
-              result: '',
+              result: {},
               bubbleText: '',
+              sentiment: '',
+              sentimentClass: '',
+              progressBarClass: '',
               principals: [
                 'costi',
                 'greg',
@@ -112,6 +122,9 @@
               ],
               principal: 'greg'
             },
+            mounted() {
+              this.focusInputQuestion();
+            },
             computed: {
               formInvalid() {
                 return this.question === '';
@@ -121,6 +134,11 @@
               }
             },
             methods: {
+              focusInputQuestion() {
+                this.$nextTick(() => {
+                  this.$refs.inputControl.focus();
+                })
+              },
               randomPrincipal() {
                 return this.principals[Math.floor(Math.random() * this.principals.length)];
               },
@@ -130,11 +148,14 @@
                   question: this.question
                 }).
                   then(response => {
+                    this.sentiment = response.data.sentiment.toLowerCase();
+                    this.progressBarClass = `progress-${this.sentiment}`;
+
                     setTimeout(() => {
                       this.loading = false;
                       this.step = 2;
                       this.principal = this.randomPrincipal();
-                      this.result = response.data.message;
+                      this.result = response.data;
                       this.speak();
                     }, 7500);
                   }).
@@ -145,7 +166,9 @@
               },
               speak() {
                 let i = 0;
-                let words = this.result.split(' ');
+                let words = this.result.message.split(' ');
+                this.sentimentClass = `sentiment-${this.sentiment}`;
+
                 let timer = setInterval(() => {
                   this.bubbleText += `${words[i]} `;
                   i ++;
@@ -156,9 +179,14 @@
               },
               reset() {
                 this.question = '';
-                this.result = '';
+                this.result = {};
                 this.bubbleText = '';
+                this.sentiment = '';
+                this.sentimentClass = '';
+                this.progressBarClass = '';
                 this.step = 1;
+
+                this.focusInputQuestion();
               }
             }
           });


### PR DESCRIPTION
- Calls AWS Comprehend for Sentiment Analysis from the server-side (RoR)
- Integrated sentiment colors into bubble text, and Thinking progress bar coloring
- Added "You Said" block on response page (including sentiment analysis)
- Updated front-page so that the Question input textarea has the focus

Did appear to require upgrading some Gems to get AWS SDK to work.

You will need an "~/.aws" folder with key files in order to properly authenticate with AWS.